### PR TITLE
Fix: Grafana Metrics Tab

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,9 +1,7 @@
 import React, { CSSProperties, FC, ReactNode, useMemo, useState } from "react";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import { Box, CircularProgress, Stack, SxProps } from "@mui/material";
 import Collapse from "@mui/material/Collapse";
-import IconButton from "@mui/material/IconButton";
+import TableSortLabel from "@mui/material/TableSortLabel";
 import {
   ColumnDef,
   ExpandedState,
@@ -14,7 +12,6 @@ import {
   getSortedRowModel,
   Row,
   RowData,
-  SortDirection,
   useReactTable,
 } from "@tanstack/react-table";
 
@@ -30,37 +27,6 @@ import {
   TableHead,
   TableRow,
 } from "./components/styled";
-
-const sortIcon = {
-  asc: ArrowUpwardIcon,
-  desc: ArrowDownwardIcon,
-};
-
-type SortIconProps = {
-  sortDirection: SortDirection | false;
-};
-
-const SortIcon: React.FC<SortIconProps> = (props) => {
-  const { sortDirection } = props;
-
-  let Icon = ArrowUpwardIcon;
-
-  if (sortDirection) {
-    Icon = sortIcon[sortDirection];
-  }
-
-  //if sort direction is available, then icon needs to be shown with darker color
-  return (
-    <IconButton size="small">
-      <Icon
-        sx={{
-          fontSize: "18px",
-          color: sortDirection ? "rgba(0,0,0,0.54)" : "rgba(0,0,0,0.27)",
-        }}
-      />
-    </IconButton>
-  );
-};
 
 type SelectionMode = "single" | "multiple" | "none";
 
@@ -195,7 +161,7 @@ const DataTable = <TData,>(props: DataTableProps<TData>): ReactNode => {
     getRowId: (row, index) => (row[rowId] != null ? String(row[rowId]) : String(index)), // Use the specified rowId property or fallback to index if not available
   });
 
-  const rowData = table.getRowModel().rows;
+  const rowData = hidePagination ? table.getPrePaginationRowModel().rows : table.getRowModel().rows;
 
   const numsColumns = table.getHeaderGroups().reduce((acc, curr) => {
     if (curr.headers.length > acc) {
@@ -284,30 +250,30 @@ const DataTable = <TData,>(props: DataTableProps<TData>): ReactNode => {
                     const sortDirection = header.column.getIsSorted();
                     const columnAlignment = header.column.columnDef.meta?.align || "left";
                     const headerStyles = header.column.columnDef.meta?.headerStyles || {};
+                    const canSort = header.column.id !== "selection" && header.column.getCanSort();
                     return (
                       <TableCell
                         align={columnAlignment}
                         key={header.id}
-                        onClick={header.column.id === "selection" ? undefined : header.column.getToggleSortingHandler()}
+                        sortDirection={sortDirection || false}
                         sx={{
-                          cursor: header.column.id === "selection" || !header.column.getCanSort() ? "auto" : "pointer",
-                          "& .MuiIconButton-root": {
-                            display: sortDirection ? "inline-flex" : "none",
-                          },
-                          "&:hover": {
-                            "& .MuiIconButton-root": {
-                              display: "inline-flex",
-                            },
-                          },
                           ...(headerStyles as Record<string, unknown>),
                         }}
                       >
-                        <Stack display="inline-flex" direction="row" gap="8px" alignItems="center">
-                          {flexRender(header.column.columnDef.header, header.getContext())}
-                          {header.column.getCanSort() && header.column.id !== "selection" && (
-                            <SortIcon sortDirection={sortDirection} />
-                          )}
-                        </Stack>
+                        {canSort ? (
+                          <TableSortLabel
+                            active={Boolean(sortDirection)}
+                            direction={sortDirection || "asc"}
+                            onClick={header.column.getToggleSortingHandler()}
+                            sx={{ "& .MuiTableSortLabel-icon": { fontSize: "18px" } }}
+                          >
+                            {flexRender(header.column.columnDef.header, header.getContext())}
+                          </TableSortLabel>
+                        ) : (
+                          <Stack display="inline-flex" direction="row" gap="8px" alignItems="center">
+                            {flexRender(header.column.columnDef.header, header.getContext())}
+                          </Stack>
+                        )}
                       </TableCell>
                     );
                   })}

--- a/src/components/ResourceInstance/Metrics/GrafanaMetrics.tsx
+++ b/src/components/ResourceInstance/Metrics/GrafanaMetrics.tsx
@@ -1,11 +1,11 @@
-import { FC, useMemo, useState } from "react";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
-import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
-import { Box, Stack, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/material";
+import { FC, useState } from "react";
+import { Box, Stack } from "@mui/material";
+import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
 
+import Button from "src/components/Button/Button";
 import CopyButton from "src/components/Button/CopyButton";
 import Card from "src/components/Card/Card";
+import DataTable from "src/components/DataTable/DataTable";
 import ExternalArrowIcon from "src/components/Icons/ArrowExternal/ArrowExternal";
 import StatusChip from "src/components/StatusChip/StatusChip";
 import { Text } from "src/components/Typography/Typography";
@@ -84,19 +84,24 @@ const CredentialColumn: FC<{
           {displayValue}
         </Text>
         {isPassword && (
-          <Text
-            size="small"
-            weight="semibold"
+          <Button
+            type="button"
+            variant="text"
+            aria-label={isVisible ? "Hide password value" : "Show password value"}
+            aria-pressed={isVisible}
             sx={{
               color: "#7F56D9",
-              cursor: "pointer",
-              userSelect: "none",
               flexShrink: 0,
+              fontSize: "14px",
+              fontWeight: 600,
+              lineHeight: "20px",
+              minWidth: 0,
+              padding: 0,
             }}
             onClick={() => setIsVisible((prev) => !prev)}
           >
             {isVisible ? "Hide" : "Show"}
-          </Text>
+          </Button>
         )}
         <CopyButton
           text={value}
@@ -116,39 +121,13 @@ type DashboardRow = {
   isAvailable: boolean;
 };
 
-type SortKey = "name" | "status";
-type SortState = { key: SortKey; direction: "asc" | "desc" } | null;
-
-const DASHBOARD_COLUMNS: {
-  key: SortKey | "action";
-  label: string;
-  width: string;
-  sortable: boolean;
-}[] = [
-  { key: "name", label: "Dashboard", width: "40%", sortable: true },
-  { key: "status", label: "Status", width: "30%", sortable: true },
-  { key: "action", label: "Action", width: "30%", sortable: false },
-];
-
-const headerCellSx = {
-  padding: "12px 24px",
-  backgroundColor: "#F9FAFB",
-  borderBottom: "1px solid #E9EAEB",
-  userSelect: "none",
-};
-
-const bodyCellSx = {
-  padding: "16px 24px",
-  borderBottom: "1px solid #E9EAEB",
-  verticalAlign: "middle",
-};
-
 const OpenDashboardLink: FC<{ link: string; disabled: boolean }> = ({ link, disabled }) => (
   <Box
     component="a"
     href={disabled ? undefined : link}
-    target="_blank"
-    rel="noopener noreferrer"
+    target={disabled ? undefined : "_blank"}
+    rel={disabled ? undefined : "noopener noreferrer"}
+    aria-disabled={disabled}
     sx={{
       display: "inline-flex",
       alignItems: "center",
@@ -168,92 +147,33 @@ const OpenDashboardLink: FC<{ link: string; disabled: boolean }> = ({ link, disa
   </Box>
 );
 
-const DashboardsTable: FC<{ rows: DashboardRow[] }> = ({ rows }) => {
-  const [sort, setSort] = useState<SortState>(null);
+const dashboardColumnHelper = createColumnHelper<DashboardRow>();
 
-  const sortedRows = useMemo(() => {
-    if (!sort) return rows;
-    const sorted = [...rows].sort((a, b) => {
-      const aValue = sort.key === "name" ? a.name : a.statusLabel;
-      const bValue = sort.key === "name" ? b.name : b.statusLabel;
-      return aValue.localeCompare(bValue);
-    });
-    return sort.direction === "asc" ? sorted : sorted.reverse();
-  }, [rows, sort]);
-
-  const handleSort = (key: SortKey) => {
-    setSort((prev) => {
-      if (prev?.key !== key) return { key, direction: "asc" };
-      return prev.direction === "asc" ? { key, direction: "desc" } : null;
-    });
-  };
-
-  return (
-    <Box sx={{ overflowX: "auto" }}>
-      <Table sx={{ tableLayout: "fixed", width: "100%", minWidth: "600px" }}>
-        <TableHead>
-          <TableRow>
-            {DASHBOARD_COLUMNS.map((column) => {
-              const isActive = sort?.key === column.key;
-              return (
-                <TableCell
-                  key={column.key}
-                  sx={{
-                    ...headerCellSx,
-                    width: column.width,
-                    cursor: column.sortable ? "pointer" : "default",
-                  }}
-                  onClick={column.sortable ? () => handleSort(column.key as SortKey) : undefined}
-                >
-                  <Stack direction="row" alignItems="center" gap="4px">
-                    <Text size="xsmall" weight="semibold" color="#717680">
-                      {column.label}
-                    </Text>
-                    {column.sortable &&
-                      (isActive ? (
-                        sort?.direction === "asc" ? (
-                          <ArrowUpwardIcon sx={{ fontSize: 14, color: "#717680" }} />
-                        ) : (
-                          <ArrowDownwardIcon sx={{ fontSize: 14, color: "#717680" }} />
-                        )
-                      ) : (
-                        <UnfoldMoreIcon sx={{ fontSize: 16, color: "#A4A7AE" }} />
-                      ))}
-                  </Stack>
-                </TableCell>
-              );
-            })}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sortedRows.map((row, index) => {
-            const isLast = index === sortedRows.length - 1;
-            const cellSx = isLast ? { ...bodyCellSx, borderBottom: "none" } : bodyCellSx;
-            return (
-              <TableRow key={row.key}>
-                <TableCell sx={cellSx}>
-                  <Text size="small" weight="medium" color="#181D27">
-                    {row.name}
-                  </Text>
-                </TableCell>
-                <TableCell sx={cellSx}>
-                  <StatusChip
-                    label={row.statusLabel}
-                    category={row.isAvailable ? "success" : "unknown"}
-                    dot
-                  />
-                </TableCell>
-                <TableCell sx={cellSx}>
-                  <OpenDashboardLink link={row.link} disabled={!row.isAvailable} />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </Box>
-  );
-};
+const DASHBOARD_COLUMNS: ColumnDef<DashboardRow>[] = [
+  dashboardColumnHelper.accessor("name", {
+    header: "Dashboard",
+    cell: ({ getValue }) => (
+      <Text size="small" weight="medium" color="#181D27">
+        {getValue()}
+      </Text>
+    ),
+    meta: { flex: 1.4, minWidth: 220 },
+  }),
+  dashboardColumnHelper.accessor("statusLabel", {
+    header: "Status",
+    cell: ({ getValue, row }) => (
+      <StatusChip label={getValue()} category={row.original.isAvailable ? "success" : "unknown"} dot />
+    ),
+    meta: { flex: 1, minWidth: 160 },
+  }),
+  dashboardColumnHelper.display({
+    id: "action",
+    header: "Action",
+    enableSorting: false,
+    cell: ({ row }) => <OpenDashboardLink link={row.original.link} disabled={!row.original.isAvailable} />,
+    meta: { flex: 1, minWidth: 200 },
+  }),
+];
 
 const GrafanaMetrics: FC<GrafanaMetricsProps> = ({ metricsFeature, instanceStatus }) => {
   if (instanceStatus === "DISCONNECTED") {
@@ -310,13 +230,17 @@ const GrafanaMetrics: FC<GrafanaMetricsProps> = ({ metricsFeature, instanceStatu
       if (bIndex !== -1) return 1;
       return a.localeCompare(b);
     })
-    .map(([key, dashboard]) => ({
-      key,
-      name: getDashboardDisplayName(dashboard.description),
-      link: dashboard.dashboardLink,
-      statusLabel: isRunning ? "Available" : "Unavailable",
-      isAvailable: isRunning && isSafeDashboardUrl(dashboard.dashboardLink),
-    }));
+    .map(([key, dashboard]) => {
+      const isAvailable = isRunning && isSafeDashboardUrl(dashboard.dashboardLink);
+
+      return {
+        key,
+        name: getDashboardDisplayName(dashboard.description),
+        link: dashboard.dashboardLink,
+        statusLabel: isAvailable ? "Available" : "Unavailable",
+        isAvailable,
+      };
+    });
 
   return (
     <Stack gap="20px" mt="32px">
@@ -360,7 +284,15 @@ const GrafanaMetrics: FC<GrafanaMetricsProps> = ({ metricsFeature, instanceStatu
         }
         contentBoxProps={{ padding: 0 }}
       >
-        <DashboardsTable rows={dashboardRows} />
+        <DataTable<DashboardRow>
+          rows={dashboardRows}
+          columns={DASHBOARD_COLUMNS}
+          rowId="key"
+          noRowsText="No dashboards available"
+          hidePagination
+          minHeight="auto"
+          tableStyles={{ border: "none", borderRadius: 0, boxShadow: "none" }}
+        />
       </ContainerCard>
     </Stack>
   );

--- a/src/components/ResourceInstance/Metrics/GrafanaMetrics.tsx
+++ b/src/components/ResourceInstance/Metrics/GrafanaMetrics.tsx
@@ -1,7 +1,9 @@
-import { FC, useState } from "react";
-import { Box, Stack } from "@mui/material";
+import { FC, useMemo, useState } from "react";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+import { Box, Stack, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/material";
 
-import Button from "src/components/Button/Button";
 import CopyButton from "src/components/Button/CopyButton";
 import Card from "src/components/Card/Card";
 import ExternalArrowIcon from "src/components/Icons/ArrowExternal/ArrowExternal";
@@ -42,166 +44,213 @@ const getDashboardDisplayName = (description: string): string => {
   return description.replace(/^instance-\S+\s+/, "");
 };
 
-const getDashboardTypeLabel = (key: string): string => {
-  if (key.includes("exporter")) {
-    return "Exporter / Service";
-  }
-  return "Grafana Dashboard";
-};
-
-const getDashboardTypeColor = (
-  key: string
-): {
-  color: string;
-  bgColor: string;
-  borderColor: string;
-} => {
-  if (key.includes("exporter")) {
-    return {
-      color: "#6941C6",
-      bgColor: "#F9F5FF",
-      borderColor: "#D6BBFB",
-    };
-  }
-  return {
-    color: "#067647",
-    bgColor: "#ECFDF3",
-    borderColor: "#ABEFC6",
-  };
-};
-
-const CredentialRow: FC<{
+const CredentialColumn: FC<{
   label: string;
   value: string;
-  isLast?: boolean;
   isPassword?: boolean;
-}> = ({ label, value, isLast = false, isPassword = false }) => {
+  showDivider?: boolean;
+}> = ({ label, value, isPassword = false, showDivider = false }) => {
   const [isVisible, setIsVisible] = useState(false);
 
-  const displayValue = isPassword && !isVisible ? "●●●●●●●●" : value;
+  const displayValue = isPassword && !isVisible ? "•".repeat(15) : value;
 
   return (
     <Stack
-      direction="row"
-      justifyContent="space-between"
-      alignItems="center"
+      gap="6px"
       sx={{
-        padding: "14px 24px",
-        borderBottom: isLast ? "none" : "1px solid #E4E7EC",
+        padding: "16px 24px",
+        minWidth: 0,
+        ...(showDivider && {
+          borderTop: { xs: "1px solid #E9EAEB", md: "none" },
+          borderLeft: { xs: "none", md: "1px solid #E9EAEB" },
+        }),
       }}
     >
-      <Text size="small" weight="medium" color="#414651">
+      <Text size="small" weight="semibold" color="#414651">
         {label}
       </Text>
-      <Stack direction="row" alignItems="center" gap="8px">
+      <Stack direction="row" alignItems="center" gap="8px" sx={{ minWidth: 0 }}>
         <Text
           size="small"
           weight="regular"
           color="#414651"
           sx={{
-            maxWidth: "400px",
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
+            minWidth: 0,
           }}
         >
           {displayValue}
         </Text>
         {isPassword && (
           <Text
-            size="xsmall"
-            weight="medium"
+            size="small"
+            weight="semibold"
             sx={{
               color: "#7F56D9",
               cursor: "pointer",
               userSelect: "none",
+              flexShrink: 0,
             }}
-            onClick={() => setIsVisible(!isVisible)}
+            onClick={() => setIsVisible((prev) => !prev)}
           >
             {isVisible ? "Hide" : "Show"}
           </Text>
         )}
         <CopyButton
           text={value}
-          iconProps={{
-            color: "#6941C6",
-            width: 18,
-            height: 18,
-          }}
-          iconButtonProps={{ padding: "4px" }}
+          iconProps={{ color: "#6941C6", width: 16, height: 16 }}
+          iconButtonProps={{ padding: "2px" }}
         />
       </Stack>
     </Stack>
   );
 };
 
-const DashboardCard: FC<{
-  dashboardKey: string;
-  dashboard: Dashboard;
-  instanceStatus?: string;
-}> = ({ dashboardKey, dashboard, instanceStatus }) => {
-  const displayName = getDashboardDisplayName(dashboard.description);
-  const typeLabel = getDashboardTypeLabel(dashboardKey);
-  const typeColor = getDashboardTypeColor(dashboardKey);
-  const linkIsSafe = isSafeDashboardUrl(dashboard.dashboardLink);
-  const isRunning = instanceStatus === "RUNNING";
+type DashboardRow = {
+  key: string;
+  name: string;
+  link: string;
+  statusLabel: string;
+  isAvailable: boolean;
+};
+
+type SortKey = "name" | "status";
+type SortState = { key: SortKey; direction: "asc" | "desc" } | null;
+
+const DASHBOARD_COLUMNS: {
+  key: SortKey | "action";
+  label: string;
+  width: string;
+  sortable: boolean;
+}[] = [
+  { key: "name", label: "Dashboard", width: "40%", sortable: true },
+  { key: "status", label: "Status", width: "30%", sortable: true },
+  { key: "action", label: "Action", width: "30%", sortable: false },
+];
+
+const headerCellSx = {
+  padding: "12px 24px",
+  backgroundColor: "#F9FAFB",
+  borderBottom: "1px solid #E9EAEB",
+  userSelect: "none",
+};
+
+const bodyCellSx = {
+  padding: "16px 24px",
+  borderBottom: "1px solid #E9EAEB",
+  verticalAlign: "middle",
+};
+
+const OpenDashboardLink: FC<{ link: string; disabled: boolean }> = ({ link, disabled }) => (
+  <Box
+    component="a"
+    href={disabled ? undefined : link}
+    target="_blank"
+    rel="noopener noreferrer"
+    sx={{
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "4px",
+      fontSize: "14px",
+      fontWeight: 600,
+      lineHeight: "20px",
+      whiteSpace: "nowrap",
+      textDecoration: "none",
+      color: disabled ? "#D0D5DD" : "#6941C6",
+      cursor: disabled ? "not-allowed" : "pointer",
+      pointerEvents: disabled ? "none" : "auto",
+    }}
+  >
+    Open Dashboard
+    <ExternalArrowIcon color={disabled ? "#D0D5DD" : "#6941C6"} width={16} height={16} />
+  </Box>
+);
+
+const DashboardsTable: FC<{ rows: DashboardRow[] }> = ({ rows }) => {
+  const [sort, setSort] = useState<SortState>(null);
+
+  const sortedRows = useMemo(() => {
+    if (!sort) return rows;
+    const sorted = [...rows].sort((a, b) => {
+      const aValue = sort.key === "name" ? a.name : a.statusLabel;
+      const bValue = sort.key === "name" ? b.name : b.statusLabel;
+      return aValue.localeCompare(bValue);
+    });
+    return sort.direction === "asc" ? sorted : sorted.reverse();
+  }, [rows, sort]);
+
+  const handleSort = (key: SortKey) => {
+    setSort((prev) => {
+      if (prev?.key !== key) return { key, direction: "asc" };
+      return prev.direction === "asc" ? { key, direction: "desc" } : null;
+    });
+  };
 
   return (
-    <Box
-      sx={{
-        border: "1px solid #E9EAEB",
-        borderRadius: "12px",
-        padding: "20px",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        gap: "12px",
-      }}
-    >
-      <Box>
-        <Stack direction="row" alignItems="center" justifyContent="space-between" gap="8px" mb="8px">
-          <Text size="medium" weight="semibold" color="#181D27">
-            {displayName}
-          </Text>
-          <StatusChip
-            label={typeLabel}
-            color={typeColor.color}
-            backgroundColor={typeColor.bgColor}
-            borderColor={typeColor.borderColor}
-            sx={{ flexShrink: 0 }}
-          />
-        </Stack>
-        {dashboard.description !== displayName && (
-          <Text size="small" weight="regular" color="#535862">
-            {dashboard.description}
-          </Text>
-        )}
-      </Box>
-
-      <Stack direction="row" alignItems="center" justifyContent="space-between">
-        {isRunning ? (
-          <StatusChip label="Available" category="success" dot />
-        ) : (
-          <StatusChip label="Unavailable" category="unknown" dot />
-        )}
-        <Button
-          variant="contained"
-          size="xsmall"
-          href={linkIsSafe ? dashboard.dashboardLink : undefined}
-          target="_blank"
-          rel="noopener noreferrer"
-          disabled={!linkIsSafe}
-          endIcon={<ExternalArrowIcon color="#FFFFFF" />}
-          sx={{
-            backgroundColor: "#7F56D9",
-            "&:hover": {
-              backgroundColor: "#6941C6",
-            },
-          }}
-        >
-          Open Dashboard
-        </Button>
-      </Stack>
+    <Box sx={{ overflowX: "auto" }}>
+      <Table sx={{ tableLayout: "fixed", width: "100%", minWidth: "600px" }}>
+        <TableHead>
+          <TableRow>
+            {DASHBOARD_COLUMNS.map((column) => {
+              const isActive = sort?.key === column.key;
+              return (
+                <TableCell
+                  key={column.key}
+                  sx={{
+                    ...headerCellSx,
+                    width: column.width,
+                    cursor: column.sortable ? "pointer" : "default",
+                  }}
+                  onClick={column.sortable ? () => handleSort(column.key as SortKey) : undefined}
+                >
+                  <Stack direction="row" alignItems="center" gap="4px">
+                    <Text size="xsmall" weight="semibold" color="#717680">
+                      {column.label}
+                    </Text>
+                    {column.sortable &&
+                      (isActive ? (
+                        sort?.direction === "asc" ? (
+                          <ArrowUpwardIcon sx={{ fontSize: 14, color: "#717680" }} />
+                        ) : (
+                          <ArrowDownwardIcon sx={{ fontSize: 14, color: "#717680" }} />
+                        )
+                      ) : (
+                        <UnfoldMoreIcon sx={{ fontSize: 16, color: "#A4A7AE" }} />
+                      ))}
+                  </Stack>
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedRows.map((row, index) => {
+            const isLast = index === sortedRows.length - 1;
+            const cellSx = isLast ? { ...bodyCellSx, borderBottom: "none" } : bodyCellSx;
+            return (
+              <TableRow key={row.key}>
+                <TableCell sx={cellSx}>
+                  <Text size="small" weight="medium" color="#181D27">
+                    {row.name}
+                  </Text>
+                </TableCell>
+                <TableCell sx={cellSx}>
+                  <StatusChip
+                    label={row.statusLabel}
+                    category={row.isAvailable ? "success" : "unknown"}
+                    dot
+                  />
+                </TableCell>
+                <TableCell sx={cellSx}>
+                  <OpenDashboardLink link={row.link} disabled={!row.isAvailable} />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
     </Box>
   );
 };
@@ -239,42 +288,79 @@ const GrafanaMetrics: FC<GrafanaMetricsProps> = ({ metricsFeature, instanceStatu
     );
   }
 
+  const isRunning = instanceStatus === "RUNNING";
+
+  const credentials = [
+    { label: "Grafana Endpoint", value: grafanaEndpoint, isPassword: false },
+    ...(metricsFeature?.instanceOrgId
+      ? [{ label: "Username", value: metricsFeature.instanceOrgId, isPassword: false }]
+      : []),
+    ...(metricsFeature?.instanceOrgPassword
+      ? [{ label: "Password", value: metricsFeature.instanceOrgPassword, isPassword: true }]
+      : []),
+  ];
+
   const dashboardOrder = ["overview", "networking"];
-  const dashboardEntries = Object.entries(dashboards).sort(([a], [b]) => {
-    const aIndex = dashboardOrder.indexOf(a);
-    const bIndex = dashboardOrder.indexOf(b);
-    if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-    if (aIndex !== -1) return -1;
-    if (bIndex !== -1) return 1;
-    return a.localeCompare(b);
-  });
+  const dashboardRows: DashboardRow[] = Object.entries(dashboards)
+    .sort(([a], [b]) => {
+      const aIndex = dashboardOrder.indexOf(a);
+      const bIndex = dashboardOrder.indexOf(b);
+      if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+      if (aIndex !== -1) return -1;
+      if (bIndex !== -1) return 1;
+      return a.localeCompare(b);
+    })
+    .map(([key, dashboard]) => ({
+      key,
+      name: getDashboardDisplayName(dashboard.description),
+      link: dashboard.dashboardLink,
+      statusLabel: isRunning ? "Available" : "Unavailable",
+      isAvailable: isRunning && isSafeDashboardUrl(dashboard.dashboardLink),
+    }));
 
   return (
     <Stack gap="20px" mt="32px">
       {/* Grafana Access Section */}
-      <ContainerCard title="Grafana Access" description="Use these credentials to access the Grafana dashboards">
-        <CredentialRow label="Grafana Endpoint" value={grafanaEndpoint} />
-        {metricsFeature.instanceOrgId && (
-          <CredentialRow label="Username" value={metricsFeature.instanceOrgId} />
-        )}
-        {metricsFeature.instanceOrgPassword && (
-          <CredentialRow label="Password" value={metricsFeature.instanceOrgPassword} isPassword isLast />
-        )}
-      </ContainerCard>
-
-      {/* Dashboards Section */}
-      <ContainerCard title="Dashboards" contentBoxProps={{ padding: "16px 24px 24px" }}>
+      <ContainerCard
+        title="Grafana Access"
+        description="Use these credentials to access the Grafana dashboards"
+        contentBoxProps={{ padding: 0 }}
+      >
         <Box
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: "16px",
+            gridTemplateColumns: {
+              xs: "1fr",
+              md: credentials.map((_, index) => (index === 0 ? "minmax(0, 1.5fr)" : "minmax(0, 1fr)")).join(" "),
+            },
           }}
         >
-          {dashboardEntries.map(([key, dashboard]) => (
-            <DashboardCard key={key} dashboardKey={key} dashboard={dashboard} instanceStatus={instanceStatus} />
+          {credentials.map((credential, index) => (
+            <CredentialColumn
+              key={credential.label}
+              label={credential.label}
+              value={credential.value}
+              isPassword={credential.isPassword}
+              showDivider={index > 0}
+            />
           ))}
         </Box>
+      </ContainerCard>
+
+      {/* Dashboards Section */}
+      <ContainerCard
+        title="Grafana Dashboards"
+        statusChip={
+          <StatusChip
+            label={String(dashboardRows.length)}
+            color="#067647"
+            backgroundColor="#ECFDF3"
+            borderColor="#ABEFC6"
+          />
+        }
+        contentBoxProps={{ padding: 0 }}
+      >
+        <DashboardsTable rows={dashboardRows} />
       </ContainerCard>
     </Stack>
   );


### PR DESCRIPTION
## Summary

The Grafana Metrics tab UI refresh introduced a one-off MUI table and mouse-only controls. It could also label a dashboard **Available** when its backend-provided URL was unsafe and the action was disabled.

This update reuses the shared `DataTable`, makes password and sort controls keyboard accessible, and derives both the status label and action state from the same running-and-safe-URL check. Users get the intended compact layout with consistent availability feedback and safe navigation.

## Impacted areas

- Deployment Instance Details → Metrics
- Shared `DataTable` sortable headers

## Validation

- Targeted ESLint and Prettier checks — passed
- `yarn tsc --noEmit` — passed

## Bug Fix - Pull Request Checklist

- [x] Have you tested all features, including both happy path scenarios and edge cases?
- [x] Have you listed the impacted areas in the PR description and tested those areas thoroughly?
- [x] Does the change affect components such as Access, Fleet, SaasBuilder, or Build? If so, has the impact been addressed and tested?
- [x] Were there any errors in the browser console during testing? If so, have those errors been resolved?
- [x] Are there any unused files, assets, or imports in the code? If so, have they been removed?
- [x] Have you added relevant test cases to cover the new changes or features?
