### PR TITLE
Fix WebSocket log URL encoding

### DIFF
--- a/src/components/ResourceInstance/Logs/Logs.jsx
+++ b/src/components/ResourceInstance/Logs/Logs.jsx
@@ -15,6 +15,7 @@ import Select from "src/components/FormElementsv2/Select/Select";
 import JobCompleted from "src/components/JobResource/JobCompleted";
 import LoadingSpinner from "src/components/LoadingSpinner/LoadingSpinner";
 import Switch from "src/components/Switch/Switch";
+import { buildLogsSocketURL } from "src/utils/logsSocketUrl";
 
 import useSnackbar from "../../../hooks/useSnackbar";
 import Card from "../../Card/Card";
@@ -111,7 +112,7 @@ function Logs(props) {
   const [errorMessage, setErrorMessage] = useState("");
   let logsSocketEndpoint = null;
   if (socketBaseURL && selectedNode) {
-    logsSocketEndpoint = `${socketBaseURL}&podName=${selectedNode.id}&instanceId=${resourceInstanceId}`;
+    logsSocketEndpoint = buildLogsSocketURL(socketBaseURL, selectedNode.id, resourceInstanceId);
   }
   if (instanceStatus === "STOPPED") {
     logsSocketEndpoint = null;

--- a/src/hooks/useResourceInstance.ts
+++ b/src/hooks/useResourceInstance.ts
@@ -3,6 +3,7 @@ import _ from "lodash";
 import { $api } from "src/api/query";
 import { getResultParams } from "src/utils/instance";
 import { calculateInstanceHealthPercentage } from "src/utils/instanceHealthPercentage";
+import { buildLogsSocketBaseURL } from "src/utils/logsSocketUrl";
 import processClusterPorts from "src/utils/processClusterPorts";
 
 const useResourceInstance = (queryParams) => {
@@ -159,12 +160,7 @@ const useResourceInstance = (queryParams) => {
             // Show Logs if Observability Resource Present
             // isLogsEnabled = true;
 
-            const clusterEndpoint = topologyDetails.clusterEndpoint;
-            const [userPass, baseURL] = clusterEndpoint.split("@");
-            if (userPass && baseURL) {
-              const [username, password] = userPass.split(":");
-              logsSocketURL = `wss://${baseURL}/logs?username=${username}&password=${password}`;
-            }
+            logsSocketURL = buildLogsSocketBaseURL(topologyDetails.clusterEndpoint);
 
             globalEndpoints.others.push({
               resourceName: topologyDetails.resourceName,

--- a/src/utils/logsSocketUrl.ts
+++ b/src/utils/logsSocketUrl.ts
@@ -1,0 +1,51 @@
+/**
+ * Builds the base logs WebSocket URL from the observability endpoint returned by the API.
+ *
+ * @example `viewer:p#ss@logs.example.com` becomes a URL whose `password` query
+ * parameter decodes to `p#ss` without creating a URL fragment.
+ */
+export const buildLogsSocketBaseURL = (clusterEndpoint?: string): string => {
+  if (!clusterEndpoint) return "";
+
+  const hostSeparatorIndex = clusterEndpoint.lastIndexOf("@");
+  const credentialSeparatorIndex = clusterEndpoint.indexOf(":");
+
+  if (
+    credentialSeparatorIndex <= 0 ||
+    hostSeparatorIndex <= credentialSeparatorIndex + 1 ||
+    hostSeparatorIndex === clusterEndpoint.length - 1
+  ) {
+    return "";
+  }
+
+  const username = clusterEndpoint.slice(0, credentialSeparatorIndex);
+  const password = clusterEndpoint.slice(credentialSeparatorIndex + 1, hostSeparatorIndex);
+  const baseURL = clusterEndpoint.slice(hostSeparatorIndex + 1);
+
+  try {
+    const socketURL = new URL(`wss://${baseURL}/logs`);
+    socketURL.searchParams.set("username", username);
+    socketURL.searchParams.set("password", password);
+    return socketURL.toString();
+  } catch {
+    return "";
+  }
+};
+
+/** Adds the selected pod and instance to an encoded logs WebSocket base URL. */
+export const buildLogsSocketURL = (
+  socketBaseURL?: string,
+  podName?: string,
+  resourceInstanceId?: string
+): string | null => {
+  if (!socketBaseURL || !podName || !resourceInstanceId) return null;
+
+  try {
+    const socketURL = new URL(socketBaseURL);
+    socketURL.searchParams.set("podName", podName);
+    socketURL.searchParams.set("instanceId", resourceInstanceId);
+    return socketURL.toString();
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- parse the observability endpoint without truncating reserved password characters
- serialize credentials, pod name, and instance ID with the URL API
- return no socket URL for malformed endpoint data instead of throwing

## Validation
- targeted ESLint
- TypeScript check
- production build with Next.js Webpack
- local reserved-character and native WebSocket constructor checks